### PR TITLE
refactor: modularize assets

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,22 @@
+body {
+  margin: 0;
+  background: linear-gradient(to bottom, #ffecd2 0%, #fcb69f 100%);
+  font-family: "Pacifico", cursive;
+  text-align: center;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+h1 {
+  margin-top: 20vh;
+  font-size: 3.5em;
+  color: #fff;
+  text-shadow: 2px 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+#canvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: -1;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,5 @@
+import { initParticles } from "./particles.js";
+
+document.addEventListener("DOMContentLoaded", () => {
+  initParticles();
+});

--- a/assets/js/particles.js
+++ b/assets/js/particles.js
@@ -1,0 +1,58 @@
+export function initParticles() {
+  const canvas = document.getElementById("canvas");
+  const ctx = canvas.getContext("2d");
+  let width, height;
+
+  function resize() {
+    width = canvas.width = window.innerWidth;
+    height = canvas.height = window.innerHeight;
+  }
+  window.addEventListener("resize", resize);
+  resize();
+
+  const particles = [];
+  const colors = ["#ff5e57", "#ffbe0b", "#3a86ff", "#8338ec", "#fb5607"];
+
+  function createParticle(x, y) {
+    const radius = Math.random() * 6 + 2;
+    const color = colors[Math.floor(Math.random() * colors.length)];
+    const dx = (Math.random() - 0.5) * 4;
+    const dy = (Math.random() - 0.5) * 4;
+    const life = 100;
+    particles.push({ x, y, dx, dy, radius, color, life });
+  }
+
+  function updateParticles() {
+    ctx.clearRect(0, 0, width, height);
+    for (let i = particles.length - 1; i >= 0; i--) {
+      const p = particles[i];
+      p.x += p.dx;
+      p.y += p.dy;
+      p.life--;
+      p.radius *= 0.96;
+      if (p.life <= 0 || p.radius < 0.5) {
+        particles.splice(i, 1);
+        continue;
+      }
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.radius, 0, Math.PI * 2);
+      ctx.fillStyle = p.color;
+      ctx.fill();
+    }
+  }
+
+  function animate() {
+    requestAnimationFrame(animate);
+    if (particles.length < 300)
+      createParticle(Math.random() * width, Math.random() * height * 0.7);
+    updateParticles();
+  }
+
+  document.body.addEventListener("click", (e) => {
+    for (let i = 0; i < 30; i++) {
+      createParticle(e.clientX, e.clientY);
+    }
+  });
+
+  animate();
+}

--- a/index.html
+++ b/index.html
@@ -1,95 +1,18 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Happy Birthday!</title>
-  <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet">
-  <style>
-    body {
-      margin: 0;
-      background: linear-gradient(to bottom, #ffecd2 0%, #fcb69f 100%);
-      font-family: 'Pacifico', cursive;
-      text-align: center;
-      overflow: hidden;
-      cursor: pointer;
-    }
-
-    h1 {
-      margin-top: 20vh;
-      font-size: 3.5em;
-      color: #fff;
-      text-shadow: 2px 2px 10px rgba(0,0,0,0.2);
-    }
-
-    #canvas {
-      position: fixed;
-      top: 0;
-      left: 0;
-      z-index: -1;
-    }
-  </style>
-</head>
-<body>
-  <h1>🎉 생일 축하합니다! 🎂</h1>
-  <canvas id="canvas"></canvas>
-
-  <script>
-    const canvas = document.getElementById('canvas');
-    const ctx = canvas.getContext('2d');
-    let width, height;
-
-    function resize() {
-      width = canvas.width = window.innerWidth;
-      height = canvas.height = window.innerHeight;
-    }
-    window.addEventListener('resize', resize);
-    resize();
-
-    const particles = [];
-    const colors = ['#ff5e57', '#ffbe0b', '#3a86ff', '#8338ec', '#fb5607'];
-
-    function createParticle(x, y) {
-      const radius = Math.random() * 6 + 2;
-      const color = colors[Math.floor(Math.random() * colors.length)];
-      const dx = (Math.random() - 0.5) * 4;
-      const dy = (Math.random() - 0.5) * 4;
-      const life = 100;
-      particles.push({ x, y, dx, dy, radius, color, life });
-    }
-
-    function updateParticles() {
-      ctx.clearRect(0, 0, width, height);
-      for (let i = particles.length - 1; i >= 0; i--) {
-        const p = particles[i];
-        p.x += p.dx;
-        p.y += p.dy;
-        p.life--;
-        p.radius *= 0.96;
-        if (p.life <= 0 || p.radius < 0.5) {
-          particles.splice(i, 1);
-          continue;
-        }
-        ctx.beginPath();
-        ctx.arc(p.x, p.y, p.radius, 0, Math.PI * 2);
-        ctx.fillStyle = p.color;
-        ctx.fill();
-      }
-    }
-
-    function animate() {
-      requestAnimationFrame(animate);
-      if (particles.length < 300) createParticle(Math.random() * width, Math.random() * height * 0.7);
-      updateParticles();
-    }
-
-    document.body.addEventListener('click', (e) => {
-      for (let i = 0; i < 30; i++) {
-        createParticle(e.clientX, e.clientY);
-      }
-    });
-
-    animate();
-  </script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Happy Birthday!</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/style.css" />
+  </head>
+  <body>
+    <h1>🎉 생일 축하합니다! 🎂</h1>
+    <canvas id="canvas"></canvas>
+    <script type="module" src="assets/js/main.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- split inline styles and scripts into separate assets for easier reuse and GitHub Pages hosting
- encapsulate particle effect logic in ES modules

## Testing
- `npx --yes prettier --check index.html assets/css/style.css assets/js/main.js assets/js/particles.js`


------
https://chatgpt.com/codex/tasks/task_e_689008e904a8832daad77510e9519fa5