### PR TITLE
feat: add interactive birthday features

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3,15 +3,38 @@ body {
   background: linear-gradient(to bottom, #ffecd2 0%, #fcb69f 100%);
   font-family: "Pacifico", cursive;
   text-align: center;
-  overflow: hidden;
-  cursor: pointer;
+  overflow-x: hidden;
 }
 
 h1 {
-  margin-top: 20vh;
+  margin-top: 40px;
   font-size: 3.5em;
   color: #fff;
   text-shadow: 2px 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+#controls {
+  margin-top: 20px;
+}
+
+button {
+  margin: 0 10px;
+  padding: 10px 20px;
+  font-size: 1em;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+#content {
+  margin-top: 20px;
+}
+
+textarea {
+  width: 80%;
+  max-width: 500px;
+  height: 120px;
+  font-family: inherit;
 }
 
 #canvas {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2,4 +2,85 @@ import { initParticles } from "./particles.js";
 
 document.addEventListener("DOMContentLoaded", () => {
   initParticles();
+
+  const content = document.getElementById("content");
+  const giftBtn = document.getElementById("giftBtn");
+  const letterBtn = document.getElementById("letterBtn");
+  const musicBtn = document.getElementById("musicBtn");
+
+  giftBtn.addEventListener("click", () => {
+    content.innerHTML = "<div class='gift'>🎁 깜짝 선물! 🎁</div>";
+  });
+
+  letterBtn.addEventListener("click", () => {
+    content.innerHTML =
+      "<div class='letter'><textarea placeholder='편지를 작성하세요...'></textarea></div>";
+  });
+
+  let audioCtx = null;
+
+  function playMelody() {
+    audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+
+    const notes = [
+      { f: 392.0, d: 0.5 },
+      { f: 392.0, d: 0.5 },
+      { f: 440.0, d: 1 },
+      { f: 392.0, d: 1 },
+      { f: 523.25, d: 1 },
+      { f: 493.88, d: 2 },
+      { f: 392.0, d: 0.5 },
+      { f: 392.0, d: 0.5 },
+      { f: 440.0, d: 1 },
+      { f: 392.0, d: 1 },
+      { f: 587.33, d: 1 },
+      { f: 523.25, d: 2 },
+      { f: 392.0, d: 0.5 },
+      { f: 392.0, d: 0.5 },
+      { f: 784.0, d: 1 },
+      { f: 659.25, d: 1 },
+      { f: 523.25, d: 1 },
+      { f: 493.88, d: 1 },
+      { f: 440.0, d: 1.5 },
+      { f: 698.46, d: 0.5 },
+      { f: 698.46, d: 0.5 },
+      { f: 659.25, d: 1 },
+      { f: 523.25, d: 1 },
+      { f: 587.33, d: 1 },
+      { f: 523.25, d: 2 },
+    ];
+
+    let t = audioCtx.currentTime;
+    notes.forEach((n) => {
+      const osc = audioCtx.createOscillator();
+      const gain = audioCtx.createGain();
+      osc.type = "sine";
+      osc.frequency.value = n.f;
+      osc.connect(gain);
+      gain.connect(audioCtx.destination);
+      gain.gain.setValueAtTime(0.3, t);
+      gain.gain.exponentialRampToValueAtTime(0.001, t + n.d);
+      osc.start(t);
+      osc.stop(t + n.d);
+      t += n.d;
+    });
+
+    setTimeout(() => {
+      audioCtx = null;
+      musicBtn.textContent = "음악 재생";
+    }, t * 1000);
+  }
+
+  musicBtn.addEventListener("click", () => {
+    if (!audioCtx) {
+      playMelody();
+      musicBtn.textContent = "음악 일시정지";
+    } else if (audioCtx.state === "running") {
+      audioCtx.suspend();
+      musicBtn.textContent = "음악 재생";
+    } else if (audioCtx.state === "suspended") {
+      audioCtx.resume();
+      musicBtn.textContent = "음악 일시정지";
+    }
+  });
 });

--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
   </head>
   <body>
     <h1>🎉 생일 축하합니다! 🎂</h1>
+    <div id="controls">
+      <button id="giftBtn">선물</button>
+      <button id="letterBtn">편지</button>
+      <button id="musicBtn">음악 재생</button>
+    </div>
+    <div id="content"></div>
     <canvas id="canvas"></canvas>
     <script type="module" src="assets/js/main.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- add gift, letter and music buttons to main page
- style buttons and page for single-page layout
- implement simple Web Audio API player for instrumental Happy Birthday melody

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68900afe8fa8832d955565c5af6caf29