### PR TITLE
Add interactive birthday buttons and music

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -5,13 +5,50 @@ body {
   text-align: center;
   overflow: hidden;
   cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  position: relative;
 }
 
 h1 {
-  margin-top: 20vh;
+  margin-top: 0;
   font-size: 3.5em;
   color: #fff;
   text-shadow: 2px 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+#buttons {
+  margin-top: 20px;
+  display: flex;
+  gap: 10px;
+}
+
+button {
+  padding: 10px 20px;
+  font-size: 1em;
+  border: none;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.8);
+  cursor: pointer;
+}
+
+#content {
+  position: absolute;
+  bottom: 5vh;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 80%;
+  color: #fff;
+  text-shadow: 1px 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+textarea {
+  width: 100%;
+  max-width: 400px;
+  font-family: sans-serif;
 }
 
 #canvas {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2,4 +2,82 @@ import { initParticles } from "./particles.js";
 
 document.addEventListener("DOMContentLoaded", () => {
   initParticles();
+
+  const giftBtn = document.getElementById("gift-btn");
+  const letterBtn = document.getElementById("letter-btn");
+  const musicBtn = document.getElementById("music-btn");
+  const content = document.getElementById("content");
+  let audioCtx = null;
+
+  giftBtn.addEventListener("click", () => {
+    content.innerHTML =
+      "<h2>🎁 깜짝 선물! 🎁</h2><p>당신의 하루가 행복으로 가득하길!</p>";
+  });
+
+  letterBtn.addEventListener("click", () => {
+    content.innerHTML =
+      '<textarea id="letter" placeholder="여기에 편지를 적어보세요..." rows="5"></textarea>';
+  });
+
+  function playMelody() {
+    const notes = [
+      { f: 392, d: 0.4 },
+      { f: 392, d: 0.4 },
+      { f: 440, d: 0.4 },
+      { f: 392, d: 0.4 },
+      { f: 523, d: 0.4 },
+      { f: 494, d: 0.8 },
+      { f: 392, d: 0.4 },
+      { f: 392, d: 0.4 },
+      { f: 440, d: 0.4 },
+      { f: 392, d: 0.4 },
+      { f: 587, d: 0.4 },
+      { f: 523, d: 0.8 },
+      { f: 392, d: 0.4 },
+      { f: 392, d: 0.4 },
+      { f: 784, d: 0.4 },
+      { f: 659, d: 0.4 },
+      { f: 523, d: 0.4 },
+      { f: 494, d: 0.4 },
+      { f: 440, d: 0.8 },
+      { f: 698, d: 0.4 },
+      { f: 698, d: 0.4 },
+      { f: 659, d: 0.4 },
+      { f: 523, d: 0.4 },
+      { f: 587, d: 0.4 },
+      { f: 523, d: 0.8 },
+    ];
+
+    audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    let current = audioCtx.currentTime;
+    notes.forEach((n) => {
+      const osc = audioCtx.createOscillator();
+      const gain = audioCtx.createGain();
+      osc.frequency.value = n.f;
+      osc.connect(gain);
+      gain.connect(audioCtx.destination);
+      osc.start(current);
+      osc.stop(current + n.d);
+      current += n.d + 0.05;
+    });
+    const total = notes.reduce((s, n) => s + n.d + 0.05, 0);
+    setTimeout(() => {
+      if (audioCtx) {
+        audioCtx.close();
+        audioCtx = null;
+        musicBtn.textContent = "🎵 음악 재생";
+      }
+    }, total * 1000);
+  }
+
+  musicBtn.addEventListener("click", () => {
+    if (audioCtx) {
+      audioCtx.close();
+      audioCtx = null;
+      musicBtn.textContent = "🎵 음악 재생";
+    } else {
+      musicBtn.textContent = "⏸ 음악 정지";
+      playMelody();
+    }
+  });
 });

--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
   </head>
   <body>
     <h1>🎉 생일 축하합니다! 🎂</h1>
+    <div id="buttons">
+      <button id="gift-btn">선물</button>
+      <button id="letter-btn">편지</button>
+      <button id="music-btn">🎵 음악 재생</button>
+    </div>
+    <div id="content"></div>
     <canvas id="canvas"></canvas>
     <script type="module" src="assets/js/main.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- center page layout and add buttons for gift, letter, and music
- load dynamic content for gift and letter
- add Web Audio API melody player with play/pause

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68900afe8fa8832d955565c5af6caf29