### PR TITLE
Display tiled photo grid above gift message

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -61,3 +61,19 @@ textarea {
   left: 0;
   z-index: -1;
 }
+
+/* Grid of photos shown with the gift message */
+.photo-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 100px);
+  gap: 5px;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.photo-grid img {
+  width: 100px;
+  height: 100px;
+  object-fit: cover;
+  border-radius: 4px;
+}

--- a/assets/gift.html
+++ b/assets/gift.html
@@ -1,3 +1,11 @@
+<div class="photo-grid">
+  <img src="assets/photos/55637fa74e97ecbe8c86ac5e8d1d9f62339e41ce89b663315d96faecd7cfd11b.png" alt="photo" />
+  <img src="assets/photos/55637fa74e97ecbe8c86ac5e8d1d9f627e6f47a71c79378b48860ead6a12bf11.png" alt="photo" />
+  <img src="assets/photos/81ba93f6f42da46c22c8cbbfd3cd4e97.jpg" alt="photo" />
+  <img src="assets/photos/F2X6il_WYAABpnR.jpg" alt="photo" />
+  <img src="assets/photos/680df2392d5b222eeef137093e1be1cd.jpg" alt="photo" />
+  <img src="assets/photos/de927bc860764aa641ce4c1baa009b5f.jpg" alt="photo" />
+</div>
 <h2>🎁 깜짝 선물 🎁</h2>
 <p>당신을 위한 특별한 선물이 도착했어요!</p>
 <p>행복한 하루 보내세요.</p>


### PR DESCRIPTION
## Summary
- Show a 3-column photo grid when the gift is opened
- Add CSS to size images consistently and arrange them in a grid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68901fd67d30832db33e529b9d5b5e42