### PR TITLE
Align gift image grid left of message

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -49,6 +49,22 @@ button {
   text-shadow: 1px 1px 4px rgba(0, 0, 0, 0.2);
 }
 
+#content.gift-layout {
+  left: 5vw;
+  transform: none;
+  width: auto;
+}
+
+.gift-text {
+  text-align: left;
+}
+
+.gift-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+}
+
 textarea {
   width: 100%;
   max-width: 400px;

--- a/assets/gift.html
+++ b/assets/gift.html
@@ -1,11 +1,16 @@
-<div class="photo-grid">
-  <img src="assets/photos/55637fa74e97ecbe8c86ac5e8d1d9f62339e41ce89b663315d96faecd7cfd11b.png" alt="photo" />
-  <img src="assets/photos/55637fa74e97ecbe8c86ac5e8d1d9f627e6f47a71c79378b48860ead6a12bf11.png" alt="photo" />
-  <img src="assets/photos/81ba93f6f42da46c22c8cbbfd3cd4e97.jpg" alt="photo" />
-  <img src="assets/photos/F2X6il_WYAABpnR.jpg" alt="photo" />
-  <img src="assets/photos/680df2392d5b222eeef137093e1be1cd.jpg" alt="photo" />
-  <img src="assets/photos/de927bc860764aa641ce4c1baa009b5f.jpg" alt="photo" />
+<div class="gift-content">
+  <div class="photo-grid">
+    <img src="assets/photos/55637fa74e97ecbe8c86ac5e8d1d9f62339e41ce89b663315d96faecd7cfd11b.png" alt="photo" />
+    <img src="assets/photos/55637fa74e97ecbe8c86ac5e8d1d9f627e6f47a71c79378b48860ead6a12bf11.png" alt="photo" />
+    <img src="assets/photos/81ba93f6f42da46c22c8cbbfd3cd4e97.jpg" alt="photo" />
+    <img src="assets/photos/F2X6il_WYAABpnR.jpg" alt="photo" />
+    <img src="assets/photos/680df2392d5b222eeef137093e1be1cd.jpg" alt="photo" />
+    <img src="assets/photos/de927bc860764aa641ce4c1baa009b5f.jpg" alt="photo" />
+  </div>
+  <div class="gift-text">
+    <h2>🎁 깜짝 선물 🎁</h2>
+    <p>당신을 위한 특별한 선물이 도착했어요!</p>
+    <p>행복한 하루 보내세요.</p>
+  </div>
 </div>
-<h2>🎁 깜짝 선물 🎁</h2>
-<p>당신을 위한 특별한 선물이 도착했어요!</p>
-<p>행복한 하루 보내세요.</p>
+

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,6 +12,7 @@ document.addEventListener("DOMContentLoaded", () => {
       .then((res) => res.text())
       .then((html) => {
         content.innerHTML = html;
+        content.classList.add("gift-layout");
       });
   });
 
@@ -20,6 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
       .then((res) => res.text())
       .then((html) => {
         content.innerHTML = html;
+        content.classList.remove("gift-layout");
       });
   });
 });


### PR DESCRIPTION
## Summary
- Prevent gift image grid from covering buttons by moving gift content to bottom-left
- Lay out gift photo grid and message side by side using flexbox
- Toggle layout via `gift-layout` class when gift or letter buttons are clicked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68902201c304832db96b5b3e6d0ab2c6