### PR TITLE
Center gift layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -50,8 +50,8 @@ button {
 }
 
 #content.gift-layout {
-  left: 5vw;
-  transform: none;
+  left: 50%;
+  transform: translateX(-50%);
   width: auto;
 }
 


### PR DESCRIPTION
## Summary
- center the gift content block so images remain left and text right but the block is centered.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68902449a134832da40f1a4675c65b1f