### PR TITLE
Adjust spacing below gift button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -53,6 +53,7 @@ button {
   left: 50%;
   transform: translateX(-50%);
   width: auto;
+  bottom: 2vh;
 }
 
 .gift-text {


### PR DESCRIPTION
## Summary
- Prevent gift content from overlapping with the gift button by lowering its container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890355f3350832db50faa508f4e1c65